### PR TITLE
Fixing advertise_addr 

### DIFF
--- a/nubis/puppet/00_nat.pp
+++ b/nubis/puppet/00_nat.pp
@@ -23,14 +23,14 @@ file { '/usr/local/bin/eni-associate':
 }
 
 # This needs to happen before nat is configured
-file { '/etc/nubis.d/98-eni-associate':
+file { '/etc/nubis.d/000-eni-associate':
     ensure  => link,
     target  => '/usr/local/bin/eni-associate',
     require => File['/usr/local/bin/eni-associate'],
 }
 
-# This is 000 on purpose it needs to run before consul
-file { '/etc/nubis.d/000-interface-fixup':
+# This is 001 on purpose it needs to run before consul
+file { '/etc/nubis.d/001-interface-fixup':
     ensure => file,
     owner  => root,
     group  => root,

--- a/nubis/puppet/files/interface-fixup
+++ b/nubis/puppet/files/interface-fixup
@@ -2,9 +2,18 @@
 
 [ -e /usr/local/lib/nubis/nubis-lib.sh ] && . /usr/local/lib/nubis/nubis-lib.sh || exit 1
 
-mac_eth1=$(__get_mac eth1)
-ip_addr=$(curl -s -fq "http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac_eth1}/local-ipv4s")
-vpc_cidr=$(curl --retry 3 -s -fq "http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac_eth1}/vpc-ipv4-cidr-block")
+# wait for mac address to be ready once
+# eni gets attached, we assume eni gets attached
+attempts=0
+until [ ! -z "${mac_eth1}" ] || [ "${attempts}" -eq 10 ]; do
+    log "Waiting on mac address of eth1 to be ready"
+    mac_eth1=$(__get_mac eth1)
+    sleep 5
+    let attempts++
+done
+
+ip_addr=$(curl --retry 5 -s -fq "http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac_eth1}/local-ipv4s")
+vpc_cidr=$(curl --retry 5 -s -fq "http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac_eth1}/vpc-ipv4-cidr-block")
 
 cat <<EOF | tee /etc/consul/interface.json
 {
@@ -12,4 +21,7 @@ cat <<EOF | tee /etc/consul/interface.json
 }
 EOF
 
-sed -i -e "s/%%VPC_CIDR%%/$vpc_cidr/g" /etc/confd/templates/iptables.tmpl
+perl -pi -e "s[%%VPC_CIDR%%][$vpc_cidr]g" /etc/confd/templates/iptables.tmpl
+
+# restarting consul to pickup advertise_addr
+service consul restart


### PR DESCRIPTION
Fixed an issue where advertise_addr doesn't get set, this happens because eth1 takes a bit to show up on the instance so we need to do a little bit of delays.

Also had to move around the order where script gets ran