### PR TITLE
Steal ENI instead of waiting for it to be available

### DIFF
--- a/nubis/puppet/files/nat/eni-associate
+++ b/nubis/puppet/files/nat/eni-associate
@@ -42,7 +42,7 @@ function _get_eni_id {
             Name=tag-value,Values=nubis-nat-eni-${environment} \
             Name=availability-zone,Values=${availability_zone}\
         --query \
-            'NetworkInterfaces[?Status == `available`][NetworkInterfaceId]'\
+            'NetworkInterfaces[*][NetworkInterfaceId]'\
         --output text
 }
 


### PR DESCRIPTION
No longer wait for eni to be available we just take it, allows us to have faster turn around during autoscaling events

Fix #57 